### PR TITLE
Convert from utf-8 to default encoding

### DIFF
--- a/SourcetrailDotnetIndexer/NameHelper.cs
+++ b/SourcetrailDotnetIndexer/NameHelper.cs
@@ -119,7 +119,10 @@ namespace SourcetrailDotnetIndexer
                 }
             }
             sb.Append("] }");
-            return sb.ToString();
+
+            byte[] nameBytes = Encoding.UTF8.GetBytes(sb.ToString());
+
+            return Encoding.Default.GetString(nameBytes, 0, nameBytes.Length);
         }
     }
 }


### PR DESCRIPTION
Returning an UTF-8 encoded string resulted in the following error from the SourcetrailDB.dll:
"Error: ill-formed UTF-8 byte"

Created [this issue](https://github.com/CoatiSoftware/SourcetrailDB/issues/43) in the SourcetrailDB repo thinking it was missing utf-8 support, however, that is not the case.

I don't know exactly where the problem is (maybe because of the interop?) but converting from utf-8 to the default encoding works for my use case and preserves diacritics.